### PR TITLE
Built-in support for component's styles. Use autoprefixer. Minify with clean-css.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 node_modules
 .idea/
 example/node_modules

--- a/index.js
+++ b/index.js
@@ -31,7 +31,11 @@ function getStylusCompiler(app) {
 
     options._imports || (options._imports = []);
     var out = {};
-    var s = stylus(file, options)
+
+    // 'file' is not actually being used. We need to alter the order component
+    // styles are plugged in so we import the specified file before
+    // importing the components' styles
+    var s = stylus('', options)
       .set('filename', filename)
       .set('include css', true);
 
@@ -45,6 +49,9 @@ function getStylusCompiler(app) {
       s.set('paths', options.paths);
       s.define('data-uri', stylus.url({ paths: options.paths }));
     }
+
+    // Add actual specified stylesheets file
+    s.import(filename);
 
     // Plug in styles from components while keeping the ability to
     // use global variables/helpers/etc defined in the main stylesheet

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ function stylusCompiler(file, filename, options) {
     if (assetsDir) options.paths = [assetsDir]
   }
   if (options.paths) {
+    s.set('paths', options.paths);
     s.define('data-uri', stylus.url({ paths: options.paths }));
   }
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var CleanCSS = require('clean-css');
 var autoprefixer = require('autoprefixer');
 var stylus  = require('stylus');
 var findup = require('findup-sync');
+var path = require('path');
 
 module.exports = function(app) {
   app.styleExtensions.push('.styl');

--- a/index.js
+++ b/index.js
@@ -19,8 +19,8 @@ function stylusCompiler(file, filename, options) {
 
   // Add data-uri() function to embed images and fonts as Data URIs.
   // It finds nearest 'public' folder unless specified.
-  if (!options.paths) {
-    var assetsDir = findup('public', {cwd: filename});
+  if (!options.paths || options.paths.length === 0) {
+    var assetsDir = findup('public', { cwd: path.dirname(filename) });
     if (assetsDir) options.paths = [assetsDir]
   }
   if (options.paths) {

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ module.exports = function(app) {
   app.compilers['.styl'] = getStylusCompiler(app);
 };
 
-// Hash of loaded component's styles to prevent component styles from loading twice
+// Hash of loaded component's styles grouped by apps.
+// Used to prevent component styles from loading twice
 var loaded = {};
 
 function getStylusCompiler(app) {

--- a/index.js
+++ b/index.js
@@ -6,42 +6,69 @@ var path = require('path');
 
 module.exports = function(app) {
   app.styleExtensions.push('.styl');
-  app.compilers['.styl'] = stylusCompiler;
+  app.compilers['.styl'] = getStylusCompiler(app);
 };
 
-function stylusCompiler(file, filename, options) {
-  options || (options = {});
-  options.browsers || (options.browsers = ['last 2 version', '> 1%', 'ie 9', 'android 4']);
-  options._imports || (options._imports = []);
-  var out = {};
-  var s = stylus(file, options)
-    .set('filename', filename)
-    .set('include css', true);
+function getStylusCompiler(app) {
 
-  // Add data-uri() function to embed images and fonts as Data URIs.
-  // It finds nearest 'public' folder unless specified.
-  if (!options.paths || options.paths.length === 0) {
-    var assetsDir = findup('public', { cwd: path.dirname(filename) });
-    if (assetsDir) options.paths = [assetsDir]
-  }
-  if (options.paths) {
-    s.set('paths', options.paths);
-    s.define('data-uri', stylus.url({ paths: options.paths }));
-  }
+  var includeComponentStyles = function (s){
+    for (var viewName in app.views.nameMap){
 
-  s.render(function(err, value) {
-    if (err) throw err;
-    out.css = value;
-  });
-  out.files = options._imports.map(function(item) {
-    return item.path;
-  });
-  out.files.push(filename);
-  // Add vendor prefixes
-  out.css = autoprefixer(options.browsers).process(out.css).css;
-  // Minify
-  if (options.compress) {
-    out.css = new CleanCSS().minify(out.css);
+      var view = app.views.nameMap[viewName];
+      if (!view.componentFactory) continue;
+
+      var style = view.componentFactory.constructor.prototype.style;
+      if (style) s.import(style);
+
+    }
+  };
+
+  return function(file, filename, options) {
+    options || (options = {});
+
+    // Default browsers for autoprefixer
+    options.browsers || (options.browsers = ['last 2 version', '> 1%', 'ie 9', 'android 4']);
+
+    options._imports || (options._imports = []);
+    var out = {};
+    var s = stylus(file, options)
+      .set('filename', filename)
+      .set('include css', true);
+
+    // Add data-uri() function to embed images and fonts as Data URIs.
+    // It finds nearest 'public' folder unless specified.
+    if (!options.paths || options.paths.length === 0) {
+      var assetsDir = findup('public', { cwd: path.dirname(filename) });
+      if (assetsDir) options.paths = [assetsDir]
+    }
+    if (options.paths) {
+      s.set('paths', options.paths);
+      s.define('data-uri', stylus.url({ paths: options.paths }));
+    }
+
+    // Plug in styles from components while keeping the ability to
+    // use global variables/helpers/etc defined in the main stylesheet
+    s.use(includeComponentStyles);
+
+    s.render(function(err, value) {
+      if (err) throw err;
+      out.css = value;
+    });
+
+    // Get all compiled files to watch for their changes
+    out.files = options._imports.map(function(item) {
+      return item.path;
+    });
+    out.files.push(filename);
+
+    // Add vendor prefixes
+    out.css = autoprefixer(options.browsers).process(out.css).css;
+
+    // Minify
+    if (options.compress) {
+      out.css = new CleanCSS().minify(out.css);
+    }
+
+    return out;
   }
-  return out;
 }

--- a/index.js
+++ b/index.js
@@ -40,15 +40,12 @@ function getStylusCompiler(app) {
       .set('include css', true);
 
     // Add data-uri() function to embed images and fonts as Data URIs.
-    // It finds nearest 'public' folder unless specified.
-    if (!options.paths || options.paths.length === 0) {
-      var assetsDir = findup('public', { cwd: path.dirname(filename) });
-      if (assetsDir) options.paths = [assetsDir]
-    }
-    if (options.paths) {
-      s.set('paths', options.paths);
-      s.define('data-uri', stylus.url({ paths: options.paths }));
-    }
+    // Find and add nearest 'public' folder to paths.
+    options.paths || (options.paths = []);
+    var assetsDir = findup('public', { cwd: path.dirname(filename) });
+    if (assetsDir) options.paths.push(assetsDir);
+    s.set('paths', options.paths);
+    s.define('data-uri', stylus.url({ paths: options.paths }));
 
     // Add actual specified stylesheets file
     s.import(filename);

--- a/index.js
+++ b/index.js
@@ -9,7 +9,13 @@ module.exports = function(app) {
   app.compilers['.styl'] = getStylusCompiler(app);
 };
 
+// Hash of loaded component's styles to prevent component styles from loading twice
+var loaded = {};
+
 function getStylusCompiler(app) {
+
+  // Keep track of loaded components for each app
+  loaded[app.name] || (loaded[app.name] = {});
 
   var includeComponentStyles = function (s){
     for (var viewName in app.views.nameMap){
@@ -18,8 +24,10 @@ function getStylusCompiler(app) {
       if (!view.componentFactory) continue;
 
       var style = view.componentFactory.constructor.prototype.style;
-      if (style) s.import(style);
-
+      if (style && !loaded[app.name][style]) {
+        loaded[app.name][style] = true;
+        s.import(style);
+      }
     }
   };
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var CleanCSS = require('clean-css');
-var autoprefixer = require('autoprefixer');
+var autoprefixer = require('autoprefixer-core');
 var stylus  = require('stylus');
 var findup = require('findup-sync');
 var path = require('path');
@@ -66,7 +66,7 @@ function getStylusCompiler(app) {
     out.files.push(filename);
 
     // Add vendor prefixes
-    out.css = autoprefixer(options.browsers).process(out.css).css;
+    out.css = autoprefixer({ browsers: options.browsers }).process(out.css).css;
 
     // Minify
     if (options.compress) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "stylus": "~0.46.3",
     "clean-css": "~2.2",
-    "autoprefixer": "~2.1",
+    "autoprefixer": "~3.1",
     "findup-sync": "^0.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
   },
   "homepage": "https://github.com/codeparty/derby-stylus",
   "dependencies": {
-    "stylus": "~0.45.1",
-    "nib": "~1.0.2"
+    "stylus": "~0.46.3",
+    "clean-css": "~2.2",
+    "autoprefixer": "~2.1",
+    "findup-sync": "^0.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/codeparty/derby-stylus",
   "dependencies": {
-    "stylus": "~0.49.2",
+    "stylus": "~0.46.3",
     "clean-css": "~2.2",
     "autoprefixer-core": "~3.1",
     "findup-sync": "^0.1.2"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "stylus": "~0.46.3",
     "clean-css": "~2.2",
-    "autoprefixer": "~3.1",
+    "autoprefixer-core": "~3.1",
     "findup-sync": "^0.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/codeparty/derby-stylus",
   "dependencies": {
-    "stylus": "~0.46.3",
+    "stylus": "~0.49.2",
     "clean-css": "~2.2",
     "autoprefixer-core": "~3.1",
     "findup-sync": "^0.1.2"


### PR DESCRIPTION
1. Add built-in support for `style` property of components:
   
   ``` js
   var Avatar = function(){};
   Avatar.prototype.view = __dirname;
   Avatar.prototype.style = __dirname;
   ```
   
   API of `loadStyles()` didn't change but the drawback is that you have to do `loadStyles()` after you've plugged in all the components.
2. Instead of nib use [autoprefixer](https://github.com/postcss/autoprefixer) to automatically add browser vendor prefixes
3. Use [clean-css](https://github.com/jakubpawlowicz/clean-css) for minification
4. Add `data-uri()` function into stylus that can be used to embed images in datauri base64 format. By default it looks for an image in the nearest `public` folder.

``` styl
embed-img($img)
  width image-size($img)[0]
  height image-size($img)[1]
  background-image data-uri($img)
.logo
  embed-img '/img/logo.png'
```
