### PR TITLE
Add options for imports and plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,27 +1,43 @@
 var stylus  = require('stylus');
+var path    = require('path');
+var fs      = require('fs');
 
-module.exports = function(app) {
+module.exports = function(app, options = {}) {
+  var { includes = [], plugins = [], ...opts } = options;
+  
+  var stylusRequirePath = require.resolve('stylus');
+  var nodeModulesRoot = stylusRequirePath.substring(0, stylusRequirePath.indexOf('/stylus'));
+
+  var includePaths = includes.reduce((acc, moduleId) => {
+    var stylusModulePath = path.join(nodeModulesRoot, moduleId);
+    return fs.existsSync(stylusModulePath)
+      ? [...acc, stylusModulePath]
+      : acc;
+  }, []);
+
+  function stylusCompiler(file, filename, options) {
+    var options = { _imports: [], ...options, ...opts };
+    var out = {};
+    var compiler = stylus(file, options)
+      .set('paths', includePaths)
+      .set('filename', filename)
+      .set('compress', options.compress)
+      .set('include css', true)
+
+    plugins.forEach(plugin => compiler.use(plugin()));
+      
+    compiler.render(function(err, value) {
+        if (err) throw err;
+        out.css = value;
+      });
+
+    out.files = options._imports.map(function(item) {
+      return item.path;
+    });
+    out.files.push(filename);
+    return out;
+  }
+
   app.styleExtensions.push('.styl');
   app.compilers['.styl'] = stylusCompiler;
 };
-
-function stylusCompiler(file, filename, options) {
-  options || (options = {});
-  options._imports || (options._imports = []);
-  var out = {};
-  var s = stylus(file, options)
-    .set('filename', filename)
-    .set('compress', options.compress)
-    .set('include css', true);
-
-
-  s.render(function(err, value) {
-    if (err) throw err;
-    out.css = value;
-  });
-  out.files = options._imports.map(function(item) {
-    return item.path;
-  });
-  out.files.push(filename);
-  return out;
-}

--- a/index.js
+++ b/index.js
@@ -24,7 +24,10 @@ module.exports = function(app, options = {}) {
       .set('compress', options.compress)
       .set('include css', true)
 
-    plugins.forEach(plugin => compiler.use(plugin()));
+    plugins.forEach(plugin => {
+      var pluginFn = require(plugin);
+      compiler.use(pluginFn());
+    });
       
     compiler.render(function(err, value) {
         if (err) throw err;

--- a/index.js
+++ b/index.js
@@ -31,9 +31,10 @@ module.exports = function(app, options = {}) {
 
   var includePaths = includes.reduce((acc, moduleId) => {
     var stylusModulePath = path.join(nodeModulesRoot, moduleId);
-    return fs.existsSync(stylusModulePath)
-      ? [...acc, stylusModulePath]
-      : acc;
+    if (fs.existsSync(stylusModulePath)) {
+      acc.push(stylusModulePath);
+    }
+     return acc;
   }, []);
 
   function stylusCompiler(file, filename, options) {

--- a/index.js
+++ b/index.js
@@ -2,6 +2,41 @@ var stylus  = require('stylus');
 var path    = require('path');
 var fs      = require('fs');
 
+var stylusUtils = require('stylus/lib/utils');
+var join = path.join;
+var dirname = path.dirname;
+var basename = path.basename;
+var relative = path.relative;
+
+var stylusLookupIndex = stylusUtils.lookupIndex;
+
+stylusUtils.lookupIndex = function(name, paths, filename){
+  var nodeModuleMatch = paths.find(includePath => includePath.endsWith(name));
+
+  var found = stylusLookupIndex(name, paths, filename);
+  
+  // check for node_modules/<name>
+  if (!found && nodeModuleMatch) {
+    found = stylusLookupIndex(nodeModuleMatch, paths, filename);
+  }
+  return found;
+
+  function lookupPackage(dir) {
+    var pkg = stylusUtils.lookup(join(dir, 'package.json'), paths, filename);
+    if (!pkg) {
+      return /\.styl$/i.test(dir) ? stylusUtils.lookupIndex(dir, paths, filename) : lookupPackage(dir + '.styl');
+    }
+    var main = require(relative(__dirname, pkg)).main;
+    if (main) {
+      found = stylusUtils.find(join(dir, main), paths, filename);
+    } else {
+      found = stylusUtils.lookupIndex(dir, paths, filename);
+    }
+    return found;
+  }
+};
+
+
 module.exports = function(app, options = {}) {
   var { includes = [], plugins = [], ...opts } = options;
   

--- a/index.js
+++ b/index.js
@@ -20,20 +20,6 @@ stylusUtils.lookupIndex = function(name, paths, filename){
     found = stylusLookupIndex(nodeModuleMatch, paths, filename);
   }
   return found;
-
-  function lookupPackage(dir) {
-    var pkg = stylusUtils.lookup(join(dir, 'package.json'), paths, filename);
-    if (!pkg) {
-      return /\.styl$/i.test(dir) ? stylusUtils.lookupIndex(dir, paths, filename) : lookupPackage(dir + '.styl');
-    }
-    var main = require(relative(__dirname, pkg)).main;
-    if (main) {
-      found = stylusUtils.find(join(dir, main), paths, filename);
-    } else {
-      found = stylusUtils.lookupIndex(dir, paths, filename);
-    }
-    return found;
-  }
 };
 
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/derbyjs/derby-stylus",
   "dependencies": {
-    "stylus": "^0.54.5"
+    "stylus": "~0.59.0"
   },
   "directories": {
     "example": "example"


### PR DESCRIPTION
Move dependency on stylus to `peerDependency` and provide  `options` to provide `imports` paths for stylesheet resolution from `node_modules`, and `plugins` for specifying stylus plugins to use (like `nib`)

Current patched version `0.1.3` still has dependency on `nib` as plugin, conflicting with `v0.2.0` and later versions of [this plugin](https://github.com/derbyjs/derby-stylus/commit/04a00ffb971c08ae38a0e91073475c993334af55) that remove `nib` as dependency. Nib, as a plugin,  may not be the right choice, or may conflict with other plugins desired, so removing this dependency and providing for option to indicate plugins to be used is provided:

Usage:
```js
app.serverUse(module, '@derbyjs/derby-stylus', {
  imports: ['branded-styles'],            // adds `branded-styles` package from `node_modules` to `paths`
  plugins: ['nib'],                       // `nib` is a dependency, specified as string
});
```

and stylesheets can `require` without relative pathing to `node_modules`

```
// for index.styl
@require 'branded-styles` 
@require 'branded-styles/icons`

// for `icons.styl`
@requrie 'branded-styles/icons'
```

instead of things like `../../node_modules/branded-styles`